### PR TITLE
Add vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    {"source": "/(.*)", "destination": "/"}
+  ]
+}


### PR DESCRIPTION
Re-write routes to base URL path. Fixes 404 routing errors when selecting a non-Create React App framework preset on Vercel.

Reference:
https://stackoverflow.com/questions/64815012/why-does-react-router-not-works-at-vercel